### PR TITLE
Fix Y module crashing if a Gate is patched into the Gate Input

### DIFF
--- a/src/Y.cpp
+++ b/src/Y.cpp
@@ -372,7 +372,8 @@ struct Y : Module {
 	}
 
 	void setAction(int action) {
-		actionCodes[codeCount++] = action;
+		if (codeCount < PORT_MAX_CHANNELS)
+			actionCodes[codeCount++] = action;
 	}
 
 	bool getAction(int action) {


### PR DESCRIPTION
Crash occurs on VCV Rack (just patch any LFO square output to the Gate input of the Y module, and then wait a couple minutes). Crash also occurs on MetaModule

The `setAction` feature seems incomplete, as `clearAction` is never called anywhere in the code, so therefore codeCount keeps increasing and there is no bounds checking when writing to `actionCodes[codeCount]`.

I don't really understand what the action feature is supposed to do or what conditions the actions are supposed to be cleared (I read through all the docs I could find)